### PR TITLE
Settings: Always show Privacy Guard permissions

### DIFF
--- a/src/com/android/settings/applications/AppOpsDetails.java
+++ b/src/com/android/settings/applications/AppOpsDetails.java
@@ -181,7 +181,7 @@ public class AppOpsDetails extends SettingsPreferenceFragment {
                  continue;
             }
             List<AppOpsState.AppOpEntry> entries = mState.buildState(tpl,
-                    mPackageInfo.applicationInfo.uid, mPackageInfo.packageName);
+                    mPackageInfo.applicationInfo.uid, mPackageInfo.packageName, true);
             for (final AppOpsState.AppOpEntry entry : entries) {
                 final AppOpsManager.OpEntry firstOp = entry.getOpEntry(0);
                 Drawable icon = null;


### PR DESCRIPTION
Enabling Privacy Guard for an app simply means switching a set of
operations to MODE_ASK, independently on whether the application
actually declared those ops (though a permission) or not. The
framework keeps track only of the ops with a non-default value. As
consequence, all the ops set by Privacy Guard that aren't declared
by the app through its manifest are effectively lost when set to
their default value and the settings won't show them.

Never hide the Privacy Guard ops to provide a consistent UI.

Change-Id: Iafcf058f5e2074982bf45f8c82ef8d027b9358f0